### PR TITLE
fix: corrected discrepancies in azure instances dataset

### DIFF
--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -76,18 +76,18 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,16.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D16s_v4,64.0
 64.00,16.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D16s_v5,64.0
 64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D2_v2,7.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D2_v31,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2_v41,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D2_v3,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2_v4,8.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2_v5,8.0
-64.00,2.0,AMD,AMD EPYC™ 7452,155.00,,,,Standard_D2a_v41,8.0
+64.00,2.0,AMD,AMD EPYC™ 7452,155.00,,,,Standard_D2a_v4,8.0
 128.00,2.0,AMD,AMD EPYC™ 7763,280.00,,,,Standard_D2ads_v5,8.0
-64.00,2.0,AMD,AMD EPYC™ 7452,155.00,,,,Standard_D2as_v42,8.0
+64.00,2.0,AMD,AMD EPYC™ 7452,155.00,,,,Standard_D2as_v4,8.0
 128.00,2.0,AMD,AMD EPYC™ 7763,280.00,,,,Standard_D2as_v5,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2d_v41,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2d_v41,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2d_v4,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2d_v4,8.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2d_v5,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2ds_v42,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2ds_v42,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2ds_v4,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2ds_v4,8.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2ds_v5,8.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2lds_v5,4.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2ls_v5,4.0
@@ -96,7 +96,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 128.00,2.0,Ampere,Ampere® Altra®,180.00,,,,Standard_D2pls_v5,4.0
 128.00,2.0,Ampere,Ampere® Altra®,180.00,,,,Standard_D2ps_v5,8.0
 64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D2s_v32,8.0
-64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2s_v42,8.0
+64.00,2.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_D2s_v4,8.0
 64.00,2.0,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_D2s_v5,8.0
 64.00,4.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D3_v2,14.0
 64.00,32.0,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_D32_v3,128.0
@@ -272,14 +272,14 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,104,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E104i_v5,672.00
 64.00,104,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E104id_v5,672.00
 64.00,104,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E104is_v5,672.00
-128.00,112,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E112iads_v53,672.00
+128.00,112,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E112iads_v5,672.00
 128.00,112,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E112ias_v5,672.00
 52.00,96,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E112ibs_v5,672.00
 64.00,16,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz",270.00,,,,Standard_E16_v3,128.00
 64.00,16,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E16_v4,128.00
 64.00,16,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E16_v5,128.00
 128.00,16,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E16a_v4,128.00
-128.00,16,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E16ads_v52,128.00
+128.00,16,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E16ads_v5,128.00
 128.00,16,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E16as_v4,128.00
 128.00,16,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E16as_v5,128.00
 52.00,16,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E16bs_v5,128.00
@@ -328,7 +328,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,32,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E32_v4,256.00
 64.00,32,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E32_v5,256.00
 128.00,32,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E32a_v4,256.00
-128.00,32,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E32ads_v52,256.00
+128.00,32,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E32ads_v5,256.00
 128.00,32,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E32as_v4,256.00
 128.00,32,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E32as_v5,256.00
 52.00,32,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E32bs_v5,256.00
@@ -360,7 +360,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,48,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E48s_v4,384.00
 64.00,48,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E48s_v5,384.00
 128.00,4,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E4a_v4,32.00
-128.00,4,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E4ads_v52,32.00
+128.00,4,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E4ads_v5,32.00
 128.00,4,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E4as_v4,32.00
 128.00,4,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E4as_v5,32.00
 52.00,4,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E4bs_v5,32.00
@@ -377,7 +377,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,64,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E64_v4,504.00
 64.00,64,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E64_v5,512.00
 128.00,64,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E64a_v4,512.00
-128.00,64,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E64ads_v52,512.00
+128.00,64,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E64ads_v5,512.00
 128.00,64,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E64as_v4,512.00
 128.00,64,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E64as_v5,512.00
 52.00,64,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E64bs_v5,512.00
@@ -396,7 +396,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,80,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E80ids_v4,504.00
 64.00,80,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL",270.00,,,,Standard_E80is_v4,504.00
 128.00,8,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E8a_v4,64.00
-128.00,8,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E8ads_v52,64.00
+128.00,8,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E8ads_v5,64.00
 128.00,8,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E8as_v4,64.00
 128.00,8,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E8as_v5,64.00
 52.00,8,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E8bs_v5,64.00
@@ -411,7 +411,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,8,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E8s_v5,64.00
 64.00,96,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E96_v5,672.00
 128.00,96,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E96a_v4,672.00
-128.00,96,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96ads_v52,672.00
+128.00,96,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96ads_v5,672.00
 128.00,96,AMD,"AMD EPYC™ 7452,AMD EPYC™ 7763",280.00,,,,Standard_E96as_v4,672.00
 128.00,96,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96as_v5,672.00
 52.00,96,Intel,Intel® Xeon® Platinum 8272CL,205.00,,,,Standard_E96bs_v5,672.00


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
## A description of the changes proposed in the Pull Request
For some of the entries in the cloud-metadata-azure-instances.csv file in the "instance-class" column, footnote markers in official Microsoft Azure documentations are mistakenly included in the names.

![image](https://github.com/Green-Software-Foundation/if-data/assets/112855405/cc492191-a6b2-49df-8b7d-c7739bc78cd6)

For example, "Standard_E64ads_v5" is written as "Standard_E64ads_v52" in the dataset, leading to errors when using the cloud-metadata plugin. In this PR, I have corrected these entries in the dataset.

(image taken from https://learn.microsoft.com/en-us/azure/virtual-machines/easv5-eadsv5-series)