### PR TITLE
Added entries for Azure instances dataset

### DIFF
--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -681,3 +681,13 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 128.00,16,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E64-16as_v5,512.00
 128.00,48,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96-48as_v5,672.00
 128.00,24,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96-24as_v5,672.00
+64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1,16.0
+64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2,16.0
+64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4,16.0
+64.00,8,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F8,16.0
+64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16,16.0
+64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1s,16.0
+64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2s,16.0
+64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4s,16.0
+64.00,8,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F8s,16.0
+64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16s,16.0

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -681,14 +681,22 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 128.00,16,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E64-16as_v5,512.00
 128.00,48,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96-48as_v5,672.00
 128.00,24,AMD,AMD EPYC™ 7763,280.00,,,,Standard_E96-24as_v5,672.00
-64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1,16.0
-64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2,16.0
-64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4,16.0
+64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1,2.0
+64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2,4.0
+64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4,8.0
 64.00,8,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F8,16.0
-64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16,16.0
-64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1s,16.0
-64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2s,16.0
-64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4s,16.0
+64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16,32.0
+64.00,1,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F1s,2.0
+64.00,2,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F2s,4.0
+64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4s,8.0
 64.00,8,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F8s,16.0
-64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16s,16.0
-52.00,2,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E64bs_v5,512.00
+64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16s,32.0
+52.00,2,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E2bds_v5,16.00
+52.00,4,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E4bds_v5,32.00
+52.00,8,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E8bds_v5,64.00
+52.00,16,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E16bds_v5,128.00
+52.00,32,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E32bds_v5,256.00
+52.00,48,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E48bds_v5,384.00
+52.00,64,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E64bds_v5,512.00
+52.00,96,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E96bds_v5,672.00
+52.00,112,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E112ibds_v5,672.00

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -700,3 +700,10 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 52.00,64,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E64bds_v5,512.00
 52.00,96,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E96bds_v5,672.00
 52.00,112,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E112ibds_v5,672.00
+64.00,1,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS11-1_v2,14.00
+64.00,2,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS12-2_v2,28.00
+64.00,1,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS12-1_v2,28.00
+64.00,4,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS13-4_v2,56.00
+64.00,2,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS13-2_v2,56.00
+64.00,8,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-8_v2,112.00
+64.00,4,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-4_v2,112.00

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -708,6 +708,6 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,8,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-8_v2,112.00
 64.00,4,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-4_v2,112.00
 64.00,4,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L4s,32.00
-64.00,8,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L8s_v2,64.00
-64.00,16,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L16s_v2,128.00
-64.00,32,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L32s_v2,256.00
+64.00,8,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L8s,64.00
+64.00,16,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L16s,128.00
+64.00,32,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L32s,256.00

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -707,3 +707,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,2,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS13-2_v2,56.00
 64.00,8,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-8_v2,112.00
 64.00,4,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-4_v2,112.00
+64.00,4,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L4s,32.00
+64.00,8,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L8s_v2,64.00
+64.00,16,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L16s_v2,128.00
+64.00,32,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L32s_v2,256.00

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -707,7 +707,7 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,2,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS13-2_v2,56.00
 64.00,8,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-8_v2,112.00
 64.00,4,Intel,"Intel® Xeon® Platinum 8370C,Intel® Xeon® Platinum 8272CL,Intel® Xeon® 8171M 2.1 GHz,Intel® Xeon® E5-2673 v4 2.3 GHz,Intel® Xeon® E5-2673 v3 2.4 GHz",270.00,,,,Standard_DS14-4_v2,112.00
-64.00,4,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L4s,32.00
-64.00,8,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L8s,64.00
-64.00,16,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L16s,128.00
-64.00,32,AMD,Intel® Xeon® processor E5 family,80.00,,,,Standard_L32s,256.00
+64.00,4,Intel,Intel® Xeon® processor E5 family,80.00,,,,Standard_L4s,32.00
+64.00,8,Intel,Intel® Xeon® processor E5 family,80.00,,,,Standard_L8s,64.00
+64.00,16,Intel,Intel® Xeon® processor E5 family,80.00,,,,Standard_L16s,128.00
+64.00,32,Intel,Intel® Xeon® processor E5 family,80.00,,,,Standard_L32s,256.00

--- a/cloud-metdata-azure-instances.csv
+++ b/cloud-metdata-azure-instances.csv
@@ -691,3 +691,4 @@ cpu-cores-available,cpu-cores-utilized,cpu-manufacturer,cpu-model-name,cpu-tdp,g
 64.00,4,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F4s,16.0
 64.00,8,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F8s,16.0
 64.00,16,Intel,"Intel® Xeon® E5-2673 v3 2.4 GHz",105.00,,,,Standard_F16s,16.0
+52.00,2,Intel,Intel® Xeon® Platinum 8370C,270.00,,,,Standard_E64bs_v5,512.00


### PR DESCRIPTION
In this PR I added entries for some Azure VM instance families that were previously missing from the azure instances cloud-metadata dataset. I added the following families:
- F-series
- Ebdsv5
- constrained D-family sizes
- first gen L-family sizes

My sources for the data are the official Microsoft Azure documentation as well as cpu-world.com to look for the TDP values.
However, for the first gen L-series, Microsoft only states that the physical processors behind the VMs for this series are from the Intel Xeon E5 processor family, which has different processors with different TDP values. Without being able to know the exact CPU being used by which VM size, I decided to take the highest TDP value of all the processors in the family. 